### PR TITLE
Switch universal selector to box-sizing: inherit

### DIFF
--- a/lib/_globals.scss
+++ b/lib/_globals.scss
@@ -4,9 +4,9 @@
 
 /* SET ALL ELEMENTS TO BOX-SIZING: BORDER-BOX */
 *, *:before, *:after {
-    -moz-box-sizing: border-box;
-    -webkit-box-sizing: border-box;
-    box-sizing: border-box;
+    -moz-box-sizing: inherit;
+    -webkit-box-sizing: inherit;
+    box-sizing: inherit;
 }
 
 * {
@@ -15,6 +15,12 @@
     -webkit-margin-start: 0;
     -webkit-margin-end: 0;
     -webkit-padding-start: 0;
+}
+
+html {
+    -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 /* http://www.filamentgroup.com/lab/how-we-learned-to-leave-body-font-size-alone.html */


### PR DESCRIPTION
This way when elements (especially embedded content) require `box-sizing: content-box` you don't have to reset all of the element's children.
